### PR TITLE
:sparkles: Discord bot: Select containers to update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,18 +10,18 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jbock.version>5.14</jbock.version>
-    <logback.version>1.4.5</logback.version>
-    <jackson.version>2.14.1</jackson.version>
+    <jbock.version>5.18</jbock.version>
+    <logback.version>1.5.8</logback.version>
+    <jackson.version>2.18.0</jackson.version>
   </properties>
 
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.13.0</version>
         <configuration>
-          <release>17</release>
+          <release>22</release>
           <annotationProcessorPaths>
             <dependency>
               <groupId>io.github.jbock-java</groupId>
@@ -34,7 +34,7 @@
 
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.4</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>shade</id>
@@ -46,16 +46,17 @@
         </executions>
         <configuration>
           <finalName>${project.name}</finalName>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
         </configuration>
       </plugin>
 
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
-        <version>3.1.4</version>
+        <version>3.4.3</version>
         <configuration>
           <from>
-            <image>openjdk:17</image>
+            <image>openjdk:22</image>
             <platforms>
               <platform>
                 <architecture>arm64</architecture>
@@ -83,7 +84,7 @@
     <dependency>
       <groupId>com.github.docker-java</groupId>
       <artifactId>docker-java</artifactId>
-      <version>3.2.14</version>
+      <version>3.4.0</version>
     </dependency>
 
     <dependency>
@@ -101,13 +102,13 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>3.1.2</version>
+      <version>3.1.8</version>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.5</version>
+      <version>2.0.16</version>
     </dependency>
 
     <dependency>
@@ -131,13 +132,13 @@
     <dependency>
       <groupId>com.cronutils</groupId>
       <artifactId>cron-utils</artifactId>
-      <version>9.2.0</version>
+      <version>9.2.1</version>
     </dependency>
 
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>5.0.0-beta.3</version>
+      <version>5.1.2</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/de/ialistannen/lighthouse/Main.java
+++ b/src/main/java/de/ialistannen/lighthouse/Main.java
@@ -50,7 +50,7 @@ public class Main {
   private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
 
   public static void main(String[] args) throws IOException, URISyntaxException, InterruptedException {
-    CliArguments arguments = new CliArgumentsParser().parseOrExit(args);
+    CliArguments arguments = CliArgumentsParser.parseOrExit(args);
     String cronTimesString = arguments.checkTimes().orElse("23 08 * * *");
     Cron cronTime = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX))
       .parse(cronTimesString)

--- a/src/main/java/de/ialistannen/lighthouse/notifier/DiscordBotNotifier.java
+++ b/src/main/java/de/ialistannen/lighthouse/notifier/DiscordBotNotifier.java
@@ -17,6 +17,8 @@ import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
+import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
+import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +104,7 @@ public class DiscordBotNotifier extends ListenerAdapter implements Notifier {
       );
     }
 
-    sendActionButtons();
+    sendActionRows(updates);
   }
 
   private EmbedBuilder buildEmbed(LighthouseContainerUpdate update) {
@@ -167,11 +169,21 @@ public class DiscordBotNotifier extends ListenerAdapter implements Notifier {
     );
   }
 
-  private void sendActionButtons() {
+  private void sendActionRows(List<LighthouseContainerUpdate> updates) {
     MessageCreateBuilder messageBuilder = new MessageCreateBuilder().setContent("\u00A0");
 
-    messageBuilder.setActionRow(
-      Button.of(ButtonStyle.PRIMARY, "update-all", "Update all!", Emoji.fromUnicode("🚀"))
+    messageBuilder.addActionRow(
+      StringSelectMenu.create("images to update")
+          .setMinValues(1)
+          .setMaxValues(25)
+          .addOptions(updates.stream()
+            .map(update -> SelectOption.of(update.names().get(0), update.names().get(0)).withDescription(update.imageUpdate().imageIdentifier().nameWithTag()).withDefault(true))
+            .toList()
+          )
+          .build()
+    );
+    messageBuilder.addActionRow(
+      Button.of(ButtonStyle.PRIMARY, "update-" + updates.hashCode(), "Update selected!", Emoji.fromUnicode("🚀"))
     );
 
     channel.sendMessage(messageBuilder.build()).queue();

--- a/src/main/java/de/ialistannen/lighthouse/notifier/DiscordBotNotifier.java
+++ b/src/main/java/de/ialistannen/lighthouse/notifier/DiscordBotNotifier.java
@@ -174,18 +174,31 @@ public class DiscordBotNotifier extends ListenerAdapter implements Notifier {
 
     messageBuilder.addActionRow(
       StringSelectMenu.create("image-select-" + updates.hashCode())
-          .setMinValues(1)
-          .setMaxValues(25)
-          .addOptions(updates.stream()
-            .map(update -> SelectOption.of(update.names().get(0), update.names().get(0)).withDescription(update.imageUpdate().imageIdentifier().nameWithTag()).withDefault(true))
+        .setMinValues(1)
+        .setMaxValues(25)
+        .addOptions(
+          updates.stream()
+            .map(DiscordBotNotifier::containerUpdateToSelectOption)
             .toList()
-          )
-          .build()
+        )
+        .build()
     );
-    messageBuilder.addActionRow(
-      Button.of(ButtonStyle.PRIMARY, "update-" + updates.hashCode(), "Update selected!", Emoji.fromUnicode("🚀"))
-    );
+    messageBuilder.addActionRow(Button.of(
+      ButtonStyle.PRIMARY,
+      "update-" + updates.hashCode(),
+      "Update selected!",
+      Emoji.fromUnicode("🚀")
+    ));
 
     channel.sendMessage(messageBuilder.build()).queue();
   }
+
+  private static SelectOption containerUpdateToSelectOption(LighthouseContainerUpdate update) {
+    String containerName = update.names().get(0);
+
+    return SelectOption.of(containerName, containerName)
+      .withDescription(update.imageUpdate().imageIdentifier().nameWithTag())
+      .withDefault(true);
+  }
+
 }

--- a/src/main/java/de/ialistannen/lighthouse/notifier/DiscordBotNotifier.java
+++ b/src/main/java/de/ialistannen/lighthouse/notifier/DiscordBotNotifier.java
@@ -173,7 +173,7 @@ public class DiscordBotNotifier extends ListenerAdapter implements Notifier {
     MessageCreateBuilder messageBuilder = new MessageCreateBuilder().setContent("\u00A0");
 
     messageBuilder.addActionRow(
-      StringSelectMenu.create("images to update")
+      StringSelectMenu.create("image-select-" + updates.hashCode())
           .setMinValues(1)
           .setMaxValues(25)
           .addOptions(updates.stream()

--- a/src/main/java/de/ialistannen/lighthouse/notifier/NtfyNotifier.java
+++ b/src/main/java/de/ialistannen/lighthouse/notifier/NtfyNotifier.java
@@ -77,7 +77,7 @@ public class NtfyNotifier implements Notifier {
     try {
       Thread.sleep(2000);
     } catch (InterruptedException e) {
-      // Update notifications should be send after image notifications, how long delayed is not important
+      // Update notifications should be sent after image notifications, how long delayed is not important
       LOGGER.debug("Interrupted while waiting for update notifications to be sent", e);
     }
     send(buildUpdateRequest(updates.size()));

--- a/src/main/java/de/ialistannen/lighthouse/updater/DiscordBotUpdateListener.java
+++ b/src/main/java/de/ialistannen/lighthouse/updater/DiscordBotUpdateListener.java
@@ -39,14 +39,15 @@ public class DiscordBotUpdateListener extends ListenerAdapter implements UpdateL
 
   @Override
   public void onButtonInteraction(ButtonInteractionEvent event) {
-    LOGGER.info("Received button interaction: {}", event.getComponentId());
+    String buttonId = event.getComponentId();
+    LOGGER.info("Received button interaction: {}", buttonId);
 
-    if (!event.getComponentId().startsWith("update-")) {
-      LOGGER.info("Unknown component id {}", event.getComponentId());
+    if (!buttonId.startsWith("update-")) {
+      LOGGER.info("Unknown component id {}", buttonId);
       event.reply("I don't know that action :/").queue();
       return;
-    } else if (!event.getComponentId().substring("update-".length()).equals(String.valueOf(lastUpdates.hashCode()))) {
-      LOGGER.info("Unknown updates for id {}", event.getComponentId());
+    } else if (!buttonId.substring("update-".length()).equals(String.valueOf(lastUpdates.hashCode()))) {
+      LOGGER.info("Unknown updates for id {}", buttonId);
       event.reply("Sorry, updating is only supported for the latest notification").queue();
       return;
     }
@@ -96,7 +97,9 @@ public class DiscordBotUpdateListener extends ListenerAdapter implements UpdateL
       LOGGER.info("Unknown component id {}", event.getComponentId());
       event.reply("I don't know that action :/").queue();
       return;
-    } else if (!event.getComponentId().substring("image-select-".length()).equals(String.valueOf(lastUpdates.hashCode()))) {
+    } else if (!event.getComponentId()
+      .substring("image-select-".length())
+      .equals(String.valueOf(lastUpdates.hashCode()))) {
       LOGGER.info("Unknown updates for id {}", event.getComponentId());
       event.reply("Sorry, selecting containers and updating is only supported for the latest notification").queue();
       return;

--- a/src/main/java/de/ialistannen/lighthouse/updater/DiscordBotUpdateListener.java
+++ b/src/main/java/de/ialistannen/lighthouse/updater/DiscordBotUpdateListener.java
@@ -91,6 +91,17 @@ public class DiscordBotUpdateListener extends ListenerAdapter implements UpdateL
   @Override
   public void onStringSelectInteraction(StringSelectInteractionEvent event) {
     LOGGER.info("Received string select interaction: {}", event.getComponentId());
+
+    if (!event.getComponentId().startsWith("image-select-")) {
+      LOGGER.info("Unknown component id {}", event.getComponentId());
+      event.reply("I don't know that action :/").queue();
+      return;
+    } else if (!event.getComponentId().substring("image-select-".length()).equals(String.valueOf(lastUpdates.hashCode()))) {
+      LOGGER.info("Unknown updates for id {}", event.getComponentId());
+      event.reply("Sorry, selecting containers and updating is only supported for the latest notification").queue();
+      return;
+    }
+
     selectedUpdates = new ArrayList<>(event.getValues());
     event.deferEdit().queue();
   }

--- a/src/main/java/de/ialistannen/lighthouse/updater/DiscordBotUpdateListener.java
+++ b/src/main/java/de/ialistannen/lighthouse/updater/DiscordBotUpdateListener.java
@@ -83,7 +83,7 @@ public class DiscordBotUpdateListener extends ListenerAdapter implements UpdateL
         LOGGER.warn("Error while updating all", throwable);
         notifier.notify(throwable);
         // Restore button
-        hook.editOriginalComponents(ActionRow.of(event.getButton())).queue();
+        hook.editOriginalComponents(event.getMessage().getComponents()).queue();
 
         return null;
       });

--- a/src/main/java/de/ialistannen/lighthouse/updates/ContainerUpdateChecker.java
+++ b/src/main/java/de/ialistannen/lighthouse/updates/ContainerUpdateChecker.java
@@ -56,7 +56,10 @@ public class ContainerUpdateChecker {
 
     Map<String, LighthouseImageUpdate> imageMap = imageUpdates.stream().collect(Collectors.toMap(
       LighthouseImageUpdate::sourceImageId,
-      it -> it
+      it -> it,
+      // merge is necessary when there are multiple running instances. In those cases an image might be present
+      // twice (potentially with differing tags). Just pick one of them for now.
+      (a, b) -> a
     ));
 
     for (Container container : client.listContainersCmd().withShowAll(true).exec()) {

--- a/src/main/java/de/ialistannen/lighthouse/updates/ContainerUpdateChecker.java
+++ b/src/main/java/de/ialistannen/lighthouse/updates/ContainerUpdateChecker.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -51,13 +52,13 @@ public class ContainerUpdateChecker {
    * @see ImageUpdateChecker#check()
    */
   public List<LighthouseContainerUpdate> check() throws IOException, URISyntaxException, InterruptedException {
-    List<LighthouseImageUpdate> imageUpdates = imageUpdateChecker.check();
+    Collection<LighthouseImageUpdate> imageUpdates = imageUpdateChecker.check();
     List<LighthouseContainerUpdate> updates = new ArrayList<>();
 
     Map<String, LighthouseImageUpdate> imageMap = imageUpdates.stream().collect(Collectors.toMap(
       LighthouseImageUpdate::sourceImageId,
       it -> it,
-      // merge is necessary when there are multiple running instances. In those cases an image might be present
+      // Merge is necessary when there are multiple running instances. In those cases an image might be present
       // twice (potentially with differing tags). Just pick one of them for now.
       (a, b) -> a
     ));

--- a/src/main/java/de/ialistannen/lighthouse/updates/ImageUpdateChecker.java
+++ b/src/main/java/de/ialistannen/lighthouse/updates/ImageUpdateChecker.java
@@ -183,7 +183,7 @@ public class ImageUpdateChecker {
           localBaseImage
         ));
       } catch (Exception e) {
-        LOGGER.warn("Failed to fetch remote info for " + Arrays.toString(container.getNames()), e);
+        LOGGER.warn("Failed to fetch remote info for {}", Arrays.toString(container.getNames()), e);
         notifier.notify(e);
       }
     }


### PR DESCRIPTION
Replaces the "Update all" button with these two actions:
![image](https://github.com/user-attachments/assets/95581675-ef5d-46f8-aaab-6400fc2583b0)
which let's you select which containers to update (initially all are selected):
![image](https://github.com/user-attachments/assets/b6bd7932-2576-46a8-aba3-d5d7386b8264)
(non-use of proper checkboxes is not my fault :( )

Additionally, interactions on previous notifications are now rejected as only the latest updates are known to the updater